### PR TITLE
add autoscaling

### DIFF
--- a/deployment/deploy_cloud.sh
+++ b/deployment/deploy_cloud.sh
@@ -40,7 +40,8 @@ python3 -m main \
     --setup_file ./setup.py \
     --template_location "gs://$2/templates/megalista" \
     --num_workers 1 \
-    --autoscaling_algorithm=NONE \
+    --autoscaling_algorithm=THROUGHPUT_BASED \
+    --number_of_worker_harness_threads=16 \
     --service_account_email "$4" \
     --collect_usage_stats "$5"
 echo "Copy megalista_medata to bucket $2"

--- a/megalista_dataflow/steps/processing_steps.py
+++ b/megalista_dataflow/steps/processing_steps.py
@@ -523,6 +523,8 @@ class GoogleAnalytics4MeasurementProtocolStep(MegalistaStep):
                 20,
                 TransactionalType.UUID,
             )
+            | "Prevent Fusion"
+            >> beam.Reshuffle()
             | "Upload - GA 4 measurement protocol"
             >> beam.ParDo(
                 GoogleAnalytics4MeasurementProtocolUploaderDoFn(


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
"This PR introduces autoscaling to the dataflow pipeline. Previously, the number of workers was set to 1 and the autoscaling algorithm was set to NONE. Now, the autoscaling algorithm is set to THROUGHPUT_BASED, which will automatically adjust the number of workers based on the workload. Additionally, the number of worker harness threads has been set to 16 to allow for parallel processing. A 'Prevent Fusion' step has also been added to the pipeline to prevent fusion optimization, which can interfere with autoscaling."

___
## PR Main Files Walkthrough:
- `megalista_dataflow/steps/processing_steps.py`: Added a 'Prevent Fusion' step to the pipeline to prevent fusion optimization, which can interfere with autoscaling.
- `deployment/deploy_cloud.sh`: Changed the autoscaling algorithm from NONE to THROUGHPUT_BASED and set the number of worker harness threads to 16. This will allow the dataflow pipeline to automatically adjust the number of workers based on the workload and allow for parallel processing.
