### PR TITLE
fix: remove secret file

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,7 +7,6 @@ steps:
         pip install --upgrade pip
         chmod +x deployment/deploy_cloud.sh
         yes | ./deployment/deploy_cloud.sh ${_PROJECT_ID} ${_BUCKET_NAME} ${_REGION} ${_SERVICE_ACCOUNT_NAME}@${_PROJECT_ID}.iam.gserviceaccount.com false
-    secretEnv: ["MEGALISTA_CONFIG_FILE"]
 substitutions:
   _BUCKET_NAME: ""
   _REGION: "europe-west1"


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
This PR addresses a security concern by removing the secret file from the Cloud Build configuration. The `MEGALISTA_CONFIG_FILE` was previously included in the `secretEnv` of the `cloudbuild.yaml` file, which could potentially expose sensitive information. This PR removes this secret environment variable to enhance the security of the application.

___
## PR Main Files Walkthrough:
- `cloudbuild.yaml`: Removed the 'MEGALISTA_CONFIG_FILE' from the 'secretEnv' field.
