### PR TITLE
Update google_analytics_4_measurement_protocol.py

### DIFF
--- a/megalista_dataflow/uploaders/google_analytics/google_analytics_4_measurement_protocol.py
+++ b/megalista_dataflow/uploaders/google_analytics/google_analytics_4_measurement_protocol.py
@@ -102,7 +102,7 @@ class GoogleAnalytics4MeasurementProtocolUploaderDoFn(MegalistaUploader):
 
       if is_user_property: 
         payload['userProperties'] = {k: {'value': v} for k, v in row.items() if self._validate_param(k, v, self.reserved_keys)}
-        payload['events'] = {'name': 'user_property_addition_event', 'params': {}}
+        payload['events'] = {'name': 'user_property_addition_event', 'params': {'engagement_time_msec' : 1}}
 
       url_container = [f'{self.API_URL}?api_secret={api_secret}']
 


### PR DESCRIPTION
## Description
- The PR adds a default engagement time of 1 millisecond to user property events to enable their display in Realtime reports in Google Analytics 4.


___

## PR changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>google_analytics_4_measurement_protocol.py&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        megalista_dataflow/uploaders/google_analytics/google_analytics_4_measurement_protocol.py<br><br>
        <strong>- Modified the payload for user property events to include <br>an engagement time parameter, setting its value to 1 <br>millisecond.</strong>
      </ul>
    </details>
  </td>
  <td><a href="https://github.com/tradelaborg/megalista/pull/11/files#diff-880c4d2eff46790fb996dfc7253dd183b74182dfb2559623099b3ce4e5d5b111"> +1/-1</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>