### PR TITLE
Fix Batch Size to handle large BigQuery writes

### DIFF
--- a/megalista_dataflow/uploaders/support/transactional_events_results_writer.py
+++ b/megalista_dataflow/uploaders/support/transactional_events_results_writer.py
@@ -71,7 +71,7 @@ class TransactionalEventsResultsWriter(beam.PTransform):
     return (
         executions
         | "Transform into tuples" >> beam.Map(lambda batch: (batch.execution.source.source_name, batch))
-        | "Group by source name" >> beam.CombinePerKey(BatchesGroupedBySourceCombineFn())
+        | "Group by source name" >> beam.GroupIntoBatches(100000)
         | "Encapsulate into object" >> beam.Map(BatchesGroupedBySourceMapper().encapsulate)
         | beam.ParDo(self._ElementsProcessor(self._error_handler))
         | beam.ParDo(self._UploadData(self._dataflow_options, self._transactional_type, self._error_handler))


### PR DESCRIPTION
## Description
- Replaced CombinePerKey with GroupIntoBatches to maintain parallelism during BigQuery writes.
- Introduced a new class _BatchElements to handle the creation of batches with a specified batch size.
- Modified GoogleAdsSSDStep to flatten, batch, format, and rebatch elements before writing results.
- Updated transactional_events_results_writer to use GroupIntoBatches instead of CombinePerKey for grouping by source name.


___

## PR changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>processing_steps.py&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        megalista_dataflow/steps/processing_steps.py<br><br>
        <strong>- Added a new class _BatchElements for batch processing.
- <br>Modified GoogleAdsSSDStep to include steps for flattening, <br>batching, formatting, and rebatching elements.
- Added <br>FormatBatchesFn to format elements within batches.</strong>
      </ul>
    </details>
  </td>
  <td><a href="https://github.com/tradelaborg/megalista/pull/12/files#diff-61ce1eb6628a690890197aa1d32f44d5090557db9be2525a7aea1b3415bab952"> +42/-1</a></td>

</tr>                    
</table></details></td></tr><tr><td><strong>Bug_fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>transactional_events_results_writer.py&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        megalista_dataflow/uploaders/support/transactional_events_results_writer.py<br><br>
        <strong>- Changed grouping method from CombinePerKey to <br>GroupIntoBatches to improve parallelism.</strong>
      </ul>
    </details>
  </td>
  <td><a href="https://github.com/tradelaborg/megalista/pull/12/files#diff-4e19748fdfb80f0f8e64391854361be6b74382f0293d577e86a9e9395e3c351c"> +1/-1</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>