### PR TITLE
Adding a fixed custom event params so we can create a filter on GA4 t…

### DIFF
--- a/megalista_dataflow/uploaders/google_analytics/google_analytics_4_measurement_protocol.py
+++ b/megalista_dataflow/uploaders/google_analytics/google_analytics_4_measurement_protocol.py
@@ -98,11 +98,12 @@ class GoogleAnalytics4MeasurementProtocolUploaderDoFn(MegalistaUploader):
       if is_event:
         event_reserved_keys = self.reserved_keys + ['name']
         params = {k: v for k, v in row.items() if self._validate_param(k, v, event_reserved_keys)}
+        params['mp_filter'] = 1
         payload['events'] = [{'name': row['name'], 'params': params}]
 
       if is_user_property: 
         payload['userProperties'] = {k: {'value': v} for k, v in row.items() if self._validate_param(k, v, self.reserved_keys)}
-        payload['events'] = {'name': 'user_property_addition_event', 'params': {'engagement_time_msec' : 1}}
+        payload['events'] = {'name': 'user_property_addition_event', 'params': {'engagement_time_msec' : 1, 'mp_filter': 1}}
 
       url_container = [f'{self.API_URL}?api_secret={api_secret}']
 


### PR DESCRIPTION
## Description
- Added a fixed custom parameter 'mp_filter' to events and user property addition payloads in the GA4 Measurement Protocol uploader.
- This parameter allows the creation of filters in Google Analytics 4 to distinguish between Measurement Protocol events and other tracked events.


___

## PR changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>google_analytics_4_measurement_protocol.py&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        megalista_dataflow/uploaders/google_analytics/google_analytics_4_measurement_protocol.py<br><br>
        <strong>- Introduced a new parameter 'mp_filter' set to 1 for both <br>event and user property payloads to facilitate filtering in <br>GA4.</strong>
      </ul>
    </details>
  </td>
  <td><a href="https://github.com/tradelaborg/megalista/pull/13/files#diff-880c4d2eff46790fb996dfc7253dd183b74182dfb2559623099b3ce4e5d5b111"> +2/-1</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>