### PR TITLE
Update google_analytics_4_measurement_protocol.py

### DIFF
--- a/megalista_dataflow/uploaders/google_analytics/google_analytics_4_measurement_protocol.py
+++ b/megalista_dataflow/uploaders/google_analytics/google_analytics_4_measurement_protocol.py
@@ -87,8 +87,15 @@ class GoogleAnalytics4MeasurementProtocolUploaderDoFn(MegalistaUploader):
       user_id = row.get('user_id')
       timestamp_micros = row.get('timestamp_micros')
 
+      # as per the GA4 MP documentation, the payload should have the following structure
+      # because "non_personalized_ads" is Obsolete:
+      # Use the ad_personalization field of consent instead of this field.
+      # Google Analytics accepts either field, but ad_personalization is recommended.
       payload: Dict[str, Any] = {
-        'nonPersonalizedAds': non_personalized_ads
+        'consent': {
+          'ad_user_data': 'GRANTED',
+          'ad_personalization': 'DENIED' if non_personalized_ads else 'GRANTED'
+        }
       }
 
       if not self._exactly_one_of(app_instance_id, client_id):


### PR DESCRIPTION
## Description
- Updated the payload structure for Google Analytics 4 Measurement Protocol to use the recommended `ad_personalization` field within the `consent` object.
- Removed the obsolete `nonPersonalizedAds` field.


___

## PR changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>google_analytics_4_measurement_protocol.py&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        megalista_dataflow/uploaders/google_analytics/google_analytics_4_measurement_protocol.py<br><br>
        <strong>Replaced the deprecated `nonPersonalizedAds` field with the <br>`ad_personalization` field inside a new `consent` object to <br>comply with the updated Google Analytics 4 Measurement <br>Protocol documentation.</strong>
      </ul>
    </details>
  </td>
  <td><a href="https://github.com/tradelaborg/megalista/pull/14/files#diff-880c4d2eff46790fb996dfc7253dd183b74182dfb2559623099b3ce4e5d5b111"> +8/-1</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>