### PR TITLE
Smooth delay for dv360 customer match & update batch size

### DIFF
--- a/megalista_dataflow/steps/processing_steps.py
+++ b/megalista_dataflow/steps/processing_steps.py
@@ -663,7 +663,7 @@ class DisplayVideoCustomerMatchContactInfoStep(MegalistaStep):
                 ),
                 self.params.dataflow_options,
                 DestinationType.DV_CUSTOMER_MATCH_CONTACT_INFO_UPLOAD,
-                1000000,
+                100000,
             )
             | "Hash Users - Display & Video Customer Match Contact Info"
             >> beam.Map(DV_CM_HASHER.hash_users)

--- a/megalista_dataflow/steps/processing_steps.py
+++ b/megalista_dataflow/steps/processing_steps.py
@@ -634,6 +634,7 @@ class DisplayVideoCustomerMatchDeviceIdStep(MegalistaStep):
                 ),
                 self.params.dataflow_options,
                 DestinationType.DV_CUSTOMER_MATCH_DEVICE_ID_UPLOAD,
+                100000,
             )
             | "Hash Users - Display & Video Customer Match Contact Info"
             >> beam.Map(DV_CM_HASHER.hash_users)

--- a/megalista_dataflow/steps/processing_steps.py
+++ b/megalista_dataflow/steps/processing_steps.py
@@ -663,7 +663,7 @@ class DisplayVideoCustomerMatchContactInfoStep(MegalistaStep):
                 ),
                 self.params.dataflow_options,
                 DestinationType.DV_CUSTOMER_MATCH_CONTACT_INFO_UPLOAD,
-                100000,
+                1000000,
             )
             | "Hash Users - Display & Video Customer Match Contact Info"
             >> beam.Map(DV_CM_HASHER.hash_users)

--- a/megalista_dataflow/steps/processing_steps.py
+++ b/megalista_dataflow/steps/processing_steps.py
@@ -663,6 +663,7 @@ class DisplayVideoCustomerMatchContactInfoStep(MegalistaStep):
                 ),
                 self.params.dataflow_options,
                 DestinationType.DV_CUSTOMER_MATCH_CONTACT_INFO_UPLOAD,
+                100000,
             )
             | "Hash Users - Display & Video Customer Match Contact Info"
             >> beam.Map(DV_CM_HASHER.hash_users)

--- a/megalista_dataflow/uploaders/display_video/customer_match/abstract_uploader.py
+++ b/megalista_dataflow/uploaders/display_video/customer_match/abstract_uploader.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import logging
-import time
+import time, random, datetime
 from typing import Dict, Any, List, Optional, Tuple
 from apache_beam.options.value_provider import StaticValueProvider
 from google.oauth2.credentials import Credentials
@@ -156,7 +156,7 @@ class DisplayVideoCustomerMatchAbstractUploaderDoFn(MegalistaUploader):
         return [{key: row.get(key) for key in keys if key in row} for row in rows]
 
     @utils.safe_process(logger=logging.getLogger(_DEFAULT_LOGGER))
-    def process(self, batch: Batch, **kwargs) -> List[Execution]:
+    def process(self, batch: Batch, retry=3, **kwargs) -> List[Execution]:
         if not self.active:
             logging.getLogger(_DEFAULT_LOGGER).info(
                 'Skipping upload to DV, parameters not configured.')
@@ -202,12 +202,27 @@ class DisplayVideoCustomerMatchAbstractUploaderDoFn(MegalistaUploader):
             )
 
             # Updates found/created audience by renewing the customer's membership list
+            self._run_execution(audience, updated_list_definition)
+
+        return [execution]
+
+    def _run_execution(self, audience, updated_list_definition, retry = 5):
+        try:
             self._get_dv_audience_service().editCustomerMatchMembers(
                 firstAndThirdPartyAudienceId=audience['firstAndThirdPartyAudienceId'],
                 body=updated_list_definition
             ).execute()
-
-        return [execution]
+        except Exception as e:
+            if retry > 0:
+                now = datetime.datetime.now()
+                seconds_to_next_minute = 62 - now.second - now.microsecond / 1000000
+                sleeping = random.choice(
+                    [seconds_to_next_minute, seconds_to_next_minute + 60, seconds_to_next_minute + 120])
+                time.sleep(sleeping)
+                logging.getLogger(_DEFAULT_LOGGER).info(f'Smooth delay in operation retry:{retry} / sleeping:{sleeping}')
+                self._run_execution(audience, updated_list_definition, retry - 1)
+            else:
+                raise e
         
     def get_list_definition(self, account_config: AccountConfig,
                             destination_metadata: List[str], list_to_add: List[Dict[str, Any]]) -> Dict[str, Any]:

--- a/megalista_dataflow/uploaders/display_video/customer_match/abstract_uploader.py
+++ b/megalista_dataflow/uploaders/display_video/customer_match/abstract_uploader.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+import time
 from typing import Dict, Any, List, Optional, Tuple
 from apache_beam.options.value_provider import StaticValueProvider
 from google.oauth2.credentials import Credentials
@@ -161,6 +162,7 @@ class DisplayVideoCustomerMatchAbstractUploaderDoFn(MegalistaUploader):
                 'Skipping upload to DV, parameters not configured.')
             return []
 
+        time.sleep(15)
         execution = batch.execution
 
         self._assert_execution_is_valid(execution)

--- a/megalista_dataflow/uploaders/display_video/customer_match/abstract_uploader.py
+++ b/megalista_dataflow/uploaders/display_video/customer_match/abstract_uploader.py
@@ -162,7 +162,7 @@ class DisplayVideoCustomerMatchAbstractUploaderDoFn(MegalistaUploader):
                 'Skipping upload to DV, parameters not configured.')
             return []
 
-        time.sleep(25)
+        time.sleep(15)
         execution = batch.execution
 
         self._assert_execution_is_valid(execution)

--- a/megalista_dataflow/uploaders/display_video/customer_match/abstract_uploader.py
+++ b/megalista_dataflow/uploaders/display_video/customer_match/abstract_uploader.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import logging
-import time
 from typing import Dict, Any, List, Optional, Tuple
 from apache_beam.options.value_provider import StaticValueProvider
 from google.oauth2.credentials import Credentials
@@ -162,7 +161,6 @@ class DisplayVideoCustomerMatchAbstractUploaderDoFn(MegalistaUploader):
                 'Skipping upload to DV, parameters not configured.')
             return []
 
-        time.sleep(15)
         execution = batch.execution
 
         self._assert_execution_is_valid(execution)

--- a/megalista_dataflow/uploaders/display_video/customer_match/abstract_uploader.py
+++ b/megalista_dataflow/uploaders/display_video/customer_match/abstract_uploader.py
@@ -162,7 +162,7 @@ class DisplayVideoCustomerMatchAbstractUploaderDoFn(MegalistaUploader):
                 'Skipping upload to DV, parameters not configured.')
             return []
 
-        time.sleep(15)
+        time.sleep(25)
         execution = batch.execution
 
         self._assert_execution_is_valid(execution)

--- a/megalista_dataflow/uploaders/display_video/customer_match/abstract_uploader.py
+++ b/megalista_dataflow/uploaders/display_video/customer_match/abstract_uploader.py
@@ -156,7 +156,7 @@ class DisplayVideoCustomerMatchAbstractUploaderDoFn(MegalistaUploader):
         return [{key: row.get(key) for key in keys if key in row} for row in rows]
 
     @utils.safe_process(logger=logging.getLogger(_DEFAULT_LOGGER))
-    def process(self, batch: Batch, retry=3, **kwargs) -> List[Execution]:
+    def process(self, batch: Batch, **kwargs) -> List[Execution]:
         if not self.active:
             logging.getLogger(_DEFAULT_LOGGER).info(
                 'Skipping upload to DV, parameters not configured.')

--- a/megalista_dataflow/uploaders/utils.py
+++ b/megalista_dataflow/uploaders/utils.py
@@ -17,6 +17,7 @@ import logging
 import pytz
 import math
 import time
+import random
 import re
 
 from typing import Optional
@@ -80,10 +81,11 @@ def safe_process(logger, retry=3):
                 return func(*args, **kwargs)
             except BaseException as e:
                 if retry > 0:
-                    logger.info(f'Smooth delay in operation {retry}')
                     now = datetime.datetime.now()
-                    seconds_to_next_minute = 60 - now.second - now.microsecond / 1000000
-                    time.sleep(seconds_to_next_minute)
+                    seconds_to_next_minute = 62 - now.second - now.microsecond / 1000000
+                    sleeping = random.choice([seconds_to_next_minute, seconds_to_next_minute+60, seconds_to_next_minute+120])
+                    time.sleep(sleeping)
+                    logger.info(f'Smooth delay in operation retry:{retry} / sleeping:{sleeping}')
                     safe_process(logger, retry - 1)(func)(*args, **kwargs)
                 else:
                     self_._add_error(batch.execution, f'Error uploading data: {e}')

--- a/megalista_dataflow/uploaders/utils.py
+++ b/megalista_dataflow/uploaders/utils.py
@@ -84,7 +84,7 @@ def safe_process(logger, retry=3):
                     now = datetime.datetime.now()
                     seconds_to_next_minute = 60 - now.second - now.microsecond / 1000000
                     time.sleep(seconds_to_next_minute)
-                    safe_process(logger, retry - 1)(*args, **kwargs)
+                    safe_process(logger, retry - 1)(func)(*args, **kwargs)
                 else:
                     self_._add_error(batch.execution, f'Error uploading data: {e}')
                     logger.error(f'Error uploading data for: {batch.execution.destination.destination_name}')


### PR DESCRIPTION
### **Description**
- Introduced a smooth delay mechanism with retries for DV360 Customer Match uploads to handle rate limiting.
- Added a fixed batch size of 100,000 for DV360 Customer Match uploads.
- Included additional imports (`time`, `random`, `datetime`) to support the new delay and retry logic.
- Implemented a `_run_execution` method to encapsulate the retry logic with exponential backoff.


___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

